### PR TITLE
Fix todo input state and consolidate item styling

### DIFF
--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -22,7 +22,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 
 export const TodoList: React.FC = () => {
   const [todos, setTodos] = useState<Todo[]>([]);
-  the [newTodoText, setNewTodoText] = useState('');
+  const [newTodoText, setNewTodoText] = useState('');
   const [newTodoPriority, setNewTodoPriority] = useState<'low' | 'medium' | 'high'>('medium');
 
   useEffect(() => {
@@ -118,7 +118,7 @@ export const TodoList: React.FC = () => {
               checked={todo.completed}
               onChange={() => handleToggleTodo(todo.id)}
             />
-            <ListItemText sx={{ textDecoration: todo.completed ? 'line-through' : 'none', color: todo.completed ? 'text.secondary' : 'text.primary' }}>
+            <ListItemText sx={{ color: todo.completed ? 'text.secondary' : 'text.primary', textDecoration: todo.completed ? 'line-through' : 'none' }}>
               {todo.text}
             </ListItemText>
           </ListItem>


### PR DESCRIPTION
## Summary
- correct new todo input state initialization
- reorder todo item styling so color state is on one line

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f75193330832eb8b75c48ba0311aa