### PR TITLE
Harden sidebar initialization and modularize default settings

### DIFF
--- a/src/modules/openTabsList/defaultSettings.ts
+++ b/src/modules/openTabsList/defaultSettings.ts
@@ -1,0 +1,17 @@
+import type { AppSettings } from '../../types/settings';
+
+export const openTabsListDefaultSettings: AppSettings['openTabsList'] = {
+  enabled: true,
+  version: '1.0.0',
+  descriptionKey: 'openTabsListDescription',
+  title: 'openTabs',
+  behavior: {
+    sortBy: 'index',
+    maxHeight: 250,
+  },
+  actions: {
+    showCopyUrl: true,
+    showDuplicateTab: true,
+    showCloseTab: true,
+  },
+};

--- a/src/modules/recentlyClosedTabs/defaultSettings.ts
+++ b/src/modules/recentlyClosedTabs/defaultSettings.ts
@@ -1,0 +1,10 @@
+import type { AppSettings } from '../../types/settings';
+
+export const recentlyClosedTabsDefaultSettings: AppSettings['recentlyClosedTabs'] = {
+  enabled: true,
+  version: '1.0.0',
+  descriptionKey: 'recentlyClosedTabsDescription',
+  title: 'recentlyClosedTabs',
+  maxTabs: 10,
+  showTime: true,
+};

--- a/src/services/DataService.ts
+++ b/src/services/DataService.ts
@@ -14,6 +14,10 @@ export class DataService {
   public static async getSettings(): Promise<AppSettings> {
     return new Promise((resolve) => {
       chrome.storage.sync.get(null, (savedSettings) => {
+        if (chrome.runtime.lastError) {
+          resolve(defaultSettings);
+          return;
+        }
         const fullSettings = merge({}, defaultSettings, savedSettings);
         resolve(fullSettings);
       });

--- a/src/services/defaultSettings.ts
+++ b/src/services/defaultSettings.ts
@@ -1,33 +1,14 @@
 // src/services/defaultSettings.ts
 
 import type { AppSettings } from '../types/settings';
+import { openTabsListDefaultSettings } from '../modules/openTabsList/defaultSettings';
+import { recentlyClosedTabsDefaultSettings } from '../modules/recentlyClosedTabs/defaultSettings';
 
 export const defaultSettings: AppSettings = {
   userName: 'Paweł',
   theme: 'system',
   todos: [],
-  openTabsList: {
-    enabled: true,
-    version: '1.0.0',
-    descriptionKey: 'openTabsListDescription',
-    title: 'openTabs',
-    behavior: {
-      sortBy: 'index',
-      maxHeight: 250,
-    },
-    actions: {
-      showCopyUrl: true,
-      showDuplicateTab: true,
-      showCloseTab: true,
-    },
-  },
-  recentlyClosedTabs: {
-    enabled: true,
-    version: '1.0.0',
-    descriptionKey: 'recentlyClosedTabsDescription',
-    title: 'recentlyClosedTabs',
-    maxTabs: 10,
-    showTime: true,
-  },
+  openTabsList: openTabsListDefaultSettings,
+  recentlyClosedTabs: recentlyClosedTabsDefaultSettings,
   newTab: {},
 };


### PR DESCRIPTION
## Summary
- Safely handle failed chrome storage reads to prevent sidebar crashes
- Move module default settings into their own files and aggregate them centrally

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f89ecd0c4832e9389261b472f8247