### PR TITLE
Handle missing tabGroups API

### DIFF
--- a/src/services/ChromeService.ts
+++ b/src/services/ChromeService.ts
@@ -20,7 +20,9 @@ export class ChromeService {
     groups: chrome.tabGroups.TabGroup[];
   }> {
     const tabs = await chrome.tabs.query({ currentWindow: true });
-    const groups = await chrome.tabGroups.query({ windowId: chrome.windows.WINDOW_ID_CURRENT });
+    const groups = chrome.tabGroups
+      ? await chrome.tabGroups.query({ windowId: chrome.windows.WINDOW_ID_CURRENT })
+      : [];
     return { tabs, groups };
   }
 


### PR DESCRIPTION
## Summary
- guard `getTabsAndGroups` against missing `chrome.tabGroups` API to prevent crashes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f8eb90348832e95a864601aece0a7